### PR TITLE
(hopefully) fixes IPA issues (Br -> Am), not returning unknown words

### DIFF
--- a/SafetySteve.py
+++ b/SafetySteve.py
@@ -1274,17 +1274,15 @@ async def sayIPA(msg, text):
             with requests. Session() as c: 
                 url = 'https://tophonetics.com/'
                 c.get(url)
-                data = dict(text_to_transcribe=text, output_dialect='am') 
+                data = dict(text_to_transcribe=text, output_dialect='am', submit="Show+transcription")
                 page = c.post(url, data=data, headers={"Referer": "https://tophonetics.com/"})
                 soup = BeautifulSoup(page.text, 'html.parser')
-                results = soup.find_all('span', attrs={'class':'transcribed_word'})
-                resultStringList = (result.text for result in results)
-                resultStringConcat = ' '.join(resultStringList)
-                if len(resultStringConcat) < 1:
+                try:
+                    IPA_text = soup.find(id='transcr_output').text
+                except AttributeError:
                     await throwError(msg, "I wasn't able to convert that word!", custom=True, printError=False)
                     return
-                else:
-                    await say(msg, resultStringConcat)
+                await say(msg, IPA_text)
         except:
             await throwError(msg, "I couldn't access `{}`!".format(url), custom=True)
 


### PR DESCRIPTION
Hi, this is my first pr ever so hopefully I don't mess it up too badly :D

This patch aims to do two things:
    - Correctly set the output language for the sayIPA function to American English
    - Allow words that can't be converted into IPA to be returned as-is instead of deleted, allowing for a more consistent experience

In my testing, these work. Unfortunately, at the moment, I don't have the full environment set up for Safety Steve, so I've tested it separately from the rest of the code, with the Discord specifics removed. As such, this version may not work 100% right away, but any errors should be trivial.

Thanks for reviewing! - Gaven