### PR TITLE
allows more words in 'good/bad bot' command

### DIFF
--- a/SafetySteve.py
+++ b/SafetySteve.py
@@ -794,7 +794,7 @@ async def on_message(msg: discord.Message):
             except:
                 continue
 
-    elif content in ['good bot', 'bad bot', 'medium bot', 'mega bad bot', 'mega good bot']:
+    elif any(word in content for word in ['good bot', 'bad bot', 'medium bot', 'mega bad bot', 'mega good bot']):
         try:
             targetMessage = None
             server = msg.guild


### PR DESCRIPTION
Allows for more text in good/bad/medium/etc. bot string: ie.
- good bot ✓
- bad bot ✓
- good bot, what a hilarious link ✓
- sorry, but bad bot ✓

but not

- this is a good thing, which is a bot ✗
- good, bot ✗
- bot, good ✗