### PR TITLE
allows more words AFTER 'good/bad bot' command

### DIFF
--- a/SafetySteve.py
+++ b/SafetySteve.py
@@ -794,7 +794,7 @@ async def on_message(msg: discord.Message):
             except:
                 continue
 
-    elif content in ['good bot', 'bad bot', 'medium bot', 'mega bad bot', 'mega good bot']:
+    elif any(word in content for word in ['good bot', 'bad bot', 'medium bot', 'mega bad bot', 'mega good bot'] if content.startswith(word)):
         try:
             targetMessage = None
             server = msg.guild


### PR DESCRIPTION
Same as other pull request, except this variation only accepts text AFTER the "____ bot" string

ie.
good bot ✓
bad bot ✓
good bot, what a hilarious link ✓
mega bad bot! I dislike you greatly, sir! ✓

sorry, but bad bot ✗
this is a good thing, which is a bot ✗
good, bot ✗
bot, good ✗
yeah I love the "good bot" command ✗