### PR TITLE
Feature/zalgo text

### DIFF
--- a/SafetySteve.py
+++ b/SafetySteve.py
@@ -767,6 +767,9 @@ async def on_message(msg: discord.Message):
                 else:
                     await say(msg, "That is not a valid item you can use! >`%s`"%(itemWanted['Name']))
             
+        if command == textCommands[26]['Command']:
+            await say(msg, await zalgo_ify(message))
+
         if command == nsfwCommands[0]['Command'] or command in nsfwCommands[0]['Alias'].split('#'):
             if await checkNSFW(msg):
                 await subreddit(msg, 'zerotwo', True)
@@ -1989,6 +1992,43 @@ def findInfo():
             despacito = voiceCommands[i]
             break
     return
+
+async def zalgo_ify(text, level=3):
+    ''' Takes some normal text and zalgo-ifies it.
+    
+    Text is passed through a diacritic-adding phase as many times as specified
+    (up to ten).
+
+    Args:
+        text (str): The string to be Zalgo-ified.
+        level (int): The number of times the text will be passed through the
+            system.
+
+    Returns:
+        str: Zalgo-ified text.
+    '''
+
+    async def zalgo_pass(text):
+        ''' A single Zolgo-ification passthrough. '''
+
+        # Chars in "Combining Diacritical Marks" Unicode block.
+        combining_chars = [chr(n) for n in range(768, 878)]
+
+        zalgo_text = ''
+        for char in text:
+            combining_char = random.choice(combining_chars)
+            zalgo_text += char + combining_char
+        return zalgo_text
+
+    if level < 0:
+        level = 1
+    elif level > 10:
+        level = 10
+
+    for i in range(level):
+        text = await zalgo_pass(text)
+
+    return text
 
 @client.event
 async def on_ready():

--- a/SafetySteve.py
+++ b/SafetySteve.py
@@ -767,15 +767,27 @@ async def on_message(msg: discord.Message):
                 else:
                     await say(msg, "That is not a valid item you can use! >`%s`"%(itemWanted['Name']))
             
-        if command == textCommands[26]['Command']:
+        if command == textCommands[26]['Command'] or command in textCommands[26]['Alias'].split('#'):
             # Get rid of original command text
             message = message.replace(command, '', 1)
 
+            # Get intensity level if applicable
             try:
                 level = int(breakdown[1])
                 message = message.replace(breakdown[1], '', 1)
-            except ValueError:
+                potential_text_breakdown_index = 2
+            except (ValueError, IndexError):
                 level = 5
+                potential_text_breakdown_index = 1
+
+            # Hacky. Sees if there's text in a string besides the command
+            # itself and the intensity number, if present.
+            try:
+                breakdown[potential_text_breakdown_index]
+            except IndexError:
+                async for m in msg.channel.history(limit=2):
+                    message = m.content
+
 
             zalgo_message = await zalgo_ify(message, level=level)
             await say(msg, zalgo_message)

--- a/SafetySteve.py
+++ b/SafetySteve.py
@@ -768,7 +768,17 @@ async def on_message(msg: discord.Message):
                     await say(msg, "That is not a valid item you can use! >`%s`"%(itemWanted['Name']))
             
         if command == textCommands[26]['Command']:
-            await say(msg, await zalgo_ify(message))
+            # Get rid of original command text
+            message = message.replace(command, '', 1)
+
+            try:
+                level = int(breakdown[1])
+                message = message.replace(breakdown[1], '', 1)
+            except ValueError:
+                level = 5
+
+            zalgo_message = await zalgo_ify(message, level=level)
+            await say(msg, zalgo_message)
 
         if command == nsfwCommands[0]['Command'] or command in nsfwCommands[0]['Alias'].split('#'):
             if await checkNSFW(msg):

--- a/SafetySteve.py
+++ b/SafetySteve.py
@@ -2047,6 +2047,10 @@ async def zalgo_ify(text, level=3):
     elif level > 10:
         level = 10
 
+    # Discord strips diacritics when there's too many chars
+    if len(text) > 30:
+        level = 1
+
     for i in range(level):
         text = await zalgo_pass(text)
 

--- a/SafetySteve.py
+++ b/SafetySteve.py
@@ -788,9 +788,11 @@ async def on_message(msg: discord.Message):
                 async for m in msg.channel.history(limit=2):
                     message = m.content
 
-
             zalgo_message = await zalgo_ify(message, level=level)
-            await say(msg, zalgo_message)
+            if message == '':
+                await say(msg, "Can't Zalgo an empty message or react.")
+            else:
+                await say(msg, zalgo_message)
 
         if command == nsfwCommands[0]['Command'] or command in nsfwCommands[0]['Alias'].split('#'):
             if await checkNSFW(msg):

--- a/config/commands.json
+++ b/config/commands.json
@@ -213,7 +213,7 @@
             "Command": "zalgo",
             "Alias": "z#zt#zalgotext#hecomes",
             "Help": "Repeats text as spooky Z̸̳͓̫̻̩̾̀̈́̎̔̋̈́͗̄͐̋̚a̸̛͕̥̱̯͔̿͝ļ̸̡͔̗̖̪͙͉̝̣̫̻͗͜ͅg̵̢̢̥̠̘̠̘̣̞͑̈́̾̑̅͂͘͘͝ȍ̸̯͈͇̟͍̪̅͊͐̈́̐̒̏̒̈́̇͆̚͜ text. Uses previous comment if no text.",
-            "Params": "[insanity level from 1-10]",
+            "Params": "[insanity level from 1-10] [text (previous comment if none)]",
             "Examples": "zalgo Hello world!"
 		}
     ],

--- a/config/commands.json
+++ b/config/commands.json
@@ -207,7 +207,15 @@
             "Help": "Uses the specified item from your inventory",
             "Params": "<item name>",
             "Examples": "item Shield#item Ward"
-        }
+        },
+
+		{
+            "Command": "zalgo",
+            "Alias": "z#zt#zalgotext#hecomes",
+            "Help": "Repeats text as spooky Z̸̳͓̫̻̩̾̀̈́̎̔̋̈́͗̄͐̋̚a̸̛͕̥̱̯͔̿͝ļ̸̡͔̗̖̪͙͉̝̣̫̻͗͜ͅg̵̢̢̥̠̘̠̘̣̞͑̈́̾̑̅͂͘͘͝ȍ̸̯͈͇̟͍̪̅͊͐̈́̐̒̏̒̈́̇͆̚͜ text. Uses previous comment if no text.",
+            "Params": "[insanity level from 1-10]",
+            "Examples": "zalgo Hello world!"
+		}
     ],
     
     "nsfw_commands":


### PR DESCRIPTION
# Zalgo text command

![Screencap](https://user-images.githubusercontent.com/48079634/67731174-b8781480-f9cd-11e9-8985-15742d559d6f.png)

Works pretty much as would be expected, pretty much like the `mock` command. Accepts these forms:

`^z`
`^zt`
`^zalgo`
`^zalgotext`
`^hecomes`

Text can be supplied immediately after the command to be Zalgo-ified. If there's none present, a previous comment will be used.

Additionally, an intensity level from 1-10 can be supplied (default is 5) directly after the command. This will work if there's text following it, or if it's using a previous comment. Intensity is automatically lowered for long texts, as Discord strips diacritics after so many characters.

---
## Tests: 


`^z Hello, world!`
> ̘̂͞h̰ͪ͞e̠͍̟ļ̪̓l̡͓̇ó̹̘,̱̗͋ ̫̎͝w̙̰͛o̶̎̕r̎̄ͣļ̽͛d̸͓͟!̛̜̞


`^z 10 Hello, world!`
> ̙͂ͪ ̩ͬ͋h̷̒̇e͛̅ͅl̛̰͂l͈̀͑ȍ͆̀,̴̣̈́ ̯ͤͅw̛̘̟o̸̅ͅrͩͭ͑l̸̹͠d̵̫ͬ!ͣ̄̆


`Hello`
`^z`
> H͓̯͞e̸̫͊l̫̒̿l̮̠ͤo̻͉̔!̨̤̲


`Hello`
`^z 1`
> H̄e̡l̈́l̈oͧ


`^z 10 I am the very model of a modern major general! I do declare!`
>  ̝i͘ ̰aͨm̈ ͩt͋h̟eͬ ͇v̰e͟r͛y͒ ̷m̷o̝d͘e̪l͎ ̭o̠f̜ ͌à ͜mͫo̸d͞ęr͇nͩ ͒m̗a̸j̫o̷r̚ ̋g͚e͙n͌e͝r͏a̽l͙!̝ ̺i̍ ̼d̺o͕ ̈́d́e̽c͆lͫa̴ȑeͫ!͛


(EMPTY OR EMBED)
`^z`
> Can't Zalgo an empty message or react.

Of course, there's also the help text:
![Screenshot_2019-10-28 Discord - Free voice and text chat for gamers(1)](https://user-images.githubusercontent.com/48079634/67732092-ad72b380-f9d0-11e9-8f64-6dd137717de1.png)