### PR TITLE
Allows for ^poll to be used even if bot can't delete original message

### DIFF
--- a/SafetySteve.py
+++ b/SafetySteve.py
@@ -429,7 +429,10 @@ async def on_message(msg: discord.Message):
                     messageEmojis = '👍 👎'
                 emojis = messageEmojis.strip().split(" ")
                 poll = await say(msg, question)
-                await msg.delete()
+                try:
+                    await msg.delete()
+                except:
+                    pass
                 for emoji in emojis:
                     try:
                         await react(poll, emoji)


### PR DESCRIPTION
`^poll` doesn't work if SafetySteve doesn't have message-deletion permissions, as it tries to delete the original message that called `^poll` and errors out

With this patch, it will work as normal on servers with that permission, but on servers without (or in DMs), it will power through and create the poll even without being able to delete the original:

![Screenshot_2019-11-22 Discord - Free voice and text chat for gamers](https://user-images.githubusercontent.com/48079634/69441205-45d22e80-0d18-11ea-89ca-9408784844b7.png)
^^ No deletion permission and still works